### PR TITLE
Set 'block_extract = true' - required for the core to load data.zip

### DIFF
--- a/libretro/core/libretro-core.c
+++ b/libretro/core/libretro-core.c
@@ -150,8 +150,7 @@ void retro_get_system_info(struct retro_system_info *info)
    info->library_version  = "021212-Dev";
    info->valid_extensions = "*|zip";
    info->need_fullpath    = true;
-   info->block_extract = false;
-
+   info->block_extract    = true;
 }
 
 void retro_get_system_av_info(struct retro_system_av_info *info)


### PR DESCRIPTION
This PR sets `block_extract = true`, which is a requirement for cores that handle loading of compressed content files internally.

The core has been violating the API for quite some time - it used to work with RetroArch by pure chance, but with https://github.com/libretro/RetroArch/commit/334a43a7c5b072d468b8cb4d6b4d1737795d12e3 the frontend now handles content 'correctly', and so the API must be followed core-side...

Closes https://github.com/libretro/RetroArch/issues/12690