### PR TITLE
Fix segfault on missing sound file

### DIFF
--- a/libretro/core/soundplay.c
+++ b/libretro/core/soundplay.c
@@ -301,6 +301,9 @@ sound_t *syssnd_load(char *name)
    sound_t *s     = malloc(sizeof(sound_t));
    data_file_t *f = data_file_open(name);
 
+   if (!s || !f)
+      return NULL;
+
    data_file_read(f, &head, 1, WAV_HEADER_SIZE);
 
    s->len         = retro_le_to_cpu32(head.Subchunk2Size);


### PR DESCRIPTION
## Description

I was testing Rick Dangerous on Kodi, and launching the core caused a segfault. I traced it down to the missing `data.zip` file containing sound effects. The fix was to add the sound files in https://github.com/kodi-game/game.libretro.xrick/pull/2, but regardless we shouldn't segfault when sounds are missing.

## How has this been tested?

When missing sounds and starting without the patch, Kodi crashes.

When missing sounds and adding the patch, the core starts.

(Obviously, when adding the sounds, the core starts with or without this patch.)