### PR TITLE
Assorted Improvements

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -29,7 +29,8 @@ STATIC_LINKING_LINK=1
 endif
 endif
 
-#CFLAGS += -DFRONTEND_SUPPORTS_RGB565
+CFLAGS += -DFRONTEND_SUPPORTS_RGB565
+
 ifeq ($(platform), android)
    CC = arm-linux-androideabi-gcc
    AR = @arm-linux-androideabi-ar
@@ -130,8 +131,8 @@ else ifeq ($(platform), ctr)
 	CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
 	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
 	DEFINES += -D_3DS -DARM11 -march=armv6k -mtune=mpcore -mfloat-abi=hard
-	CFLAGS += $(DEFINES) -DFRONTEND_SUPPORTS_RGB565
-	CXXFLAGS += $(DEFINES) -DFRONTEND_SUPPORTS_RGB565
+	CFLAGS += $(DEFINES)
+	CXXFLAGS += $(DEFINES)
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 

--- a/include/config.h
+++ b/include/config.h
@@ -23,10 +23,8 @@
 /* sound support */
 #define ENABLE_SOUND
 
-#ifndef __LIBRETRO__
 /* cheats support */
 #define ENABLE_CHEATS
-#endif
 
 /* development tools */
 #undef ENABLE_DEVTOOLS

--- a/include/game.h
+++ b/include/game.h
@@ -33,10 +33,26 @@
 #define GAME_BOMBS_INIT 6
 #define GAME_BULLETS_INIT 6
 
+typedef enum {
+#ifdef ENABLE_DEVTOOLS
+  DEVTOOLS,
+#endif
+  XRICK,
+  INIT_GAME, INIT_BUFFER,
+  INTRO_MAIN, INTRO_MAP,
+  PAUSE_PRESSED1, PAUSE_PRESSED1B, PAUSED, PAUSE_PRESSED2,
+  PLAY0, PLAY1, PLAY2, PLAY3,
+  CHAIN_SUBMAP, CHAIN_MAP, CHAIN_END,
+  SCROLL_UP, SCROLL_DOWN,
+  RESTART, GAMEOVER, GETNAME, EXIT
+} game_state_t;
+
 typedef struct {
   U32 score;
   U8 name[10];
 } hscore_t;
+
+extern game_state_t game_state; /* current game state */
 
 extern U8 game_lives;      /* lives counter */
 extern U8 game_bombs;      /* bombs counter */
@@ -62,12 +78,12 @@ extern void game_run(void);
 extern void game_setmusic(char *name, U8 loop);
 extern void game_stopmusic(void);
 
-
 #ifdef ENABLE_CHEATS
 extern U8 game_cheat1;     /* infinite lives, bombs and bullets */
 extern U8 game_cheat2;     /* never die */
 extern U8 game_cheat3;     /* highlight sprites */
-extern void game_toggleCheat(U8);
+extern void game_toggleCheat(U8 nbr);
+extern void game_enableCheats(U8 enable1, U8 enable2, U8 enable3);
 #endif
 
 #ifdef ENABLE_SOUND

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -4,7 +4,7 @@ CORE_DIR := $(LOCAL_PATH)/..
 
 include $(CORE_DIR)/Makefile.common
 
-COREFLAGS := -DANDROID -D__LIBRETRO__ $(INCFLAGS) -DWANT_ZLIB -DINLINE="inline"
+COREFLAGS := -DANDROID -D__LIBRETRO__ -DFRONTEND_SUPPORTS_RGB565 $(INCFLAGS) -DWANT_ZLIB -DINLINE="inline"
 
 GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
 ifneq ($(GIT_VERSION)," unknown")

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -283,6 +283,9 @@ enum retro_language
    RETRO_LANGUAGE_HEBREW              = 21,
    RETRO_LANGUAGE_ASTURIAN            = 22,
    RETRO_LANGUAGE_FINNISH             = 23,
+   RETRO_LANGUAGE_INDONESIAN          = 24,
+   RETRO_LANGUAGE_SWEDISH             = 25,
+   RETRO_LANGUAGE_UKRAINIAN           = 26,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -1720,6 +1723,37 @@ enum retro_mod
                                             * Used by the frontend to update the menu display status
                                             * of core options without requiring a call of retro_run().
                                             * Must be called in retro_set_environment().
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_VARIABLE 70
+                                           /* const struct retro_variable * --
+                                            * Allows an implementation to notify the frontend
+                                            * that a core option value has changed.
+                                            *
+                                            * retro_variable::key and retro_variable::value
+                                            * must match strings that have been set previously
+                                            * via one of the following:
+                                            *
+                                            * - RETRO_ENVIRONMENT_SET_VARIABLES
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL
+                                            *
+                                            * After changing a core option value via this
+                                            * callback, RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE
+                                            * will return true.
+                                            *
+                                            * If data is NULL, no changes will be registered
+                                            * and the callback will return true; an
+                                            * implementation may therefore pass NULL in order
+                                            * to test whether the callback is supported.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_THROTTLE_STATE (71 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_throttle_state * --
+                                            * Allows an implementation to get details on the actual rate
+                                            * the frontend is attempting to call retro_run().
                                             */
 
 /* VFS functionality */
@@ -3430,6 +3464,10 @@ struct retro_core_option_definition
    const char *default_value;
 };
 
+#ifdef __PS3__
+#undef local
+#endif
+
 struct retro_core_options_intl
 {
    /* Pointer to an array of retro_core_option_definition structs
@@ -3665,6 +3703,43 @@ struct retro_fastforwarding_override
     * 'inhibit_toggle' is set to false, or the core
     * is unloaded */
    bool inhibit_toggle;
+};
+
+/* During normal operation. Rate will be equal to the core's internal FPS. */
+#define RETRO_THROTTLE_NONE              0
+
+/* While paused or stepping single frames. Rate will be 0. */
+#define RETRO_THROTTLE_FRAME_STEPPING    1
+
+/* During fast forwarding.
+ * Rate will be 0 if not specifically limited to a maximum speed. */
+#define RETRO_THROTTLE_FAST_FORWARD      2
+
+/* During slow motion. Rate will be less than the core's internal FPS. */
+#define RETRO_THROTTLE_SLOW_MOTION       3
+
+/* While rewinding recorded save states. Rate can vary depending on the rewind
+ * speed or be 0 if the frontend is not aiming for a specific rate. */
+#define RETRO_THROTTLE_REWINDING         4
+
+/* While vsync is active in the video driver and the target refresh rate is
+ * lower than the core's internal FPS. Rate is the target refresh rate. */
+#define RETRO_THROTTLE_VSYNC             5
+
+/* When the frontend does not throttle in any way. Rate will be 0.
+ * An example could be if no vsync or audio output is active. */
+#define RETRO_THROTTLE_UNBLOCKED         6
+
+struct retro_throttle_state
+{
+   /* The current throttling mode. Should be one of the values above. */
+   unsigned mode;
+
+   /* How many times per second the frontend aims to call retro_run.
+    * Depending on the mode, it can be 0 if there is no known fixed rate.
+    * This won't be accurate if the total processing time of the core and
+    * the frontend is longer than what is available for one frame. */
+   float rate;
 };
 
 /* Callbacks */

--- a/libretro/core/libretro-core.h
+++ b/libretro/core/libretro-core.h
@@ -17,7 +17,7 @@ extern uint16_t Retro_Screen[WINDOW_WIDTH*WINDOW_HEIGHT];
 #define PIXEL_BYTES 1
 #define PIXEL_TYPE uint16_t
 #else
-extern unsigned int Retro_Screen[WINDOW_WIDTH*WINDOW_HEIGHT];
+extern uint32_t Retro_Screen[WINDOW_WIDTH*WINDOW_HEIGHT];
 #define PIXEL_BYTES 2
 #define PIXEL_TYPE uint32_t 
 #endif 

--- a/libretro/core/libretro_core_options.h
+++ b/libretro/core/libretro_core_options.h
@@ -1,0 +1,449 @@
+#ifndef LIBRETRO_CORE_OPTIONS_H__
+#define LIBRETRO_CORE_OPTIONS_H__
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <libretro.h>
+#include <retro_inline.h>
+
+#ifndef HAVE_NO_LANGEXTRA
+#include "libretro_core_options_intl.h"
+#endif
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_ENGLISH */
+
+/* Default language:
+ * - All other languages must include the same keys and values
+ * - Will be used as a fallback in the event that frontend language
+ *   is not available
+ * - Will be used as a fallback for any missing entries in
+ *   frontend language definition */
+
+struct retro_core_option_v2_category option_cats_us[] = {
+   {
+      "cheats",
+      "Cheats",
+      "Configure internal trainer/cheat modes provided by the game engine."
+   },
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
+   {
+      "xrick_crop_borders",
+      "Crop Borders",
+      NULL,
+      "Remove the 32 pixels of empty padding either side of the game screen. Note: Cheat mode indicators will only be shown if cropping is disabled.",
+      NULL,
+      NULL,
+      {
+         { "enabled",  NULL },
+         { "disabled", NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "xrick_cheat1",
+      "Cheat: Trainer Mode",
+      "Trainer Mode",
+      "Always have 6 bullets, 6 dynamite stick, 6 lives.",
+      NULL,
+      "cheats",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "xrick_cheat2",
+      "Cheat: Invulnerability Mode",
+      "Invulnerability Mode",
+      "Nothing can kill Rick. Use with care. May break the game.",
+      NULL,
+      "cheats",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "xrick_cheat3",
+      "Cheat: Expose Mode",
+      "Expose Mode",
+      "Highlight all entities on the game map.",
+      NULL,
+      "cheats",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
+};
+
+/*
+ ********************************
+ * Language Mapping
+ ********************************
+*/
+
+#ifndef HAVE_NO_LANGEXTRA
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,        /* RETRO_LANGUAGE_JAPANESE */
+   NULL,        /* RETRO_LANGUAGE_FRENCH */
+   NULL,        /* RETRO_LANGUAGE_SPANISH */
+   NULL,        /* RETRO_LANGUAGE_GERMAN */
+   NULL,        /* RETRO_LANGUAGE_ITALIAN */
+   NULL,        /* RETRO_LANGUAGE_DUTCH */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,        /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,        /* RETRO_LANGUAGE_KOREAN */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,        /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,        /* RETRO_LANGUAGE_POLISH */
+   NULL,        /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,        /* RETRO_LANGUAGE_ARABIC */
+   NULL,        /* RETRO_LANGUAGE_GREEK */
+   NULL,        /* RETRO_LANGUAGE_TURKISH */
+   NULL,        /* RETRO_LANGUAGE_SLOVAK */
+   NULL,        /* RETRO_LANGUAGE_PERSIAN */
+   NULL,        /* RETRO_LANGUAGE_HEBREW */
+   NULL,        /* RETRO_LANGUAGE_ASTURIAN */
+   NULL,        /* RETRO_LANGUAGE_FINNISH */
+   NULL,        /* RETRO_LANGUAGE_INDONESIAN */
+   NULL,        /* RETRO_LANGUAGE_SWEDISH */
+   NULL,        /* RETRO_LANGUAGE_UKRAINIAN */
+};
+#endif
+
+/*
+ ********************************
+ * Functions
+ ********************************
+*/
+
+/* Handles configuration/setting of core options.
+ * Should be called as early as possible - ideally inside
+ * retro_set_environment(), and no later than retro_load_game()
+ * > We place the function body in the header to avoid the
+ *   necessity of adding more .c files (i.e. want this to
+ *   be as painless as possible for core devs)
+ */
+
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
+{
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
+
+   if (!environ_cb || !categories_supported)
+      return;
+
+   *categories_supported = false;
+
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
+   {
+#ifndef HAVE_NO_LANGEXTRA
+      struct retro_core_options_v2_intl core_options_intl;
+
+      core_options_intl.us    = &options_us;
+      core_options_intl.local = NULL;
+
+      if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+          (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
+         core_options_intl.local = options_intl[language];
+
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
+#else
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
+#endif
+   }
+   else
+   {
+      size_t i, j;
+      size_t option_index              = 0;
+      size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
+      struct retro_variable *variables = NULL;
+      char **values_buf                = NULL;
+
+      /* Determine total number of options */
+      while (true)
+      {
+         if (option_defs_us[num_options].key)
+            num_options++;
+         else
+            break;
+      }
+
+      if (version >= 1)
+      {
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
+
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
+            while (true)
+            {
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
+               else
+                  break;
+            }
+
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
+            {
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
+
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
+
+               /* Values must be copied individually... */
+               while (option_values->value)
+               {
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
+               }
+            }
+         }
+
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
+      }
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
+      }
+
+error:
+      /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
+      if (values_buf)
+      {
+         for (i = 0; i < num_options; i++)
+         {
+            if (values_buf[i])
+            {
+               free(values_buf[i]);
+               values_buf[i] = NULL;
+            }
+         }
+
+         free(values_buf);
+         values_buf = NULL;
+      }
+
+      if (variables)
+      {
+         free(variables);
+         variables = NULL;
+      }
+   }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libretro/core/libretro_core_options_intl.h
+++ b/libretro/core/libretro_core_options_intl.h
@@ -1,0 +1,91 @@
+﻿#ifndef LIBRETRO_CORE_OPTIONS_INTL_H__
+#define LIBRETRO_CORE_OPTIONS_INTL_H__
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1500 && _MSC_VER < 1900)
+/* https://support.microsoft.com/en-us/kb/980263 */
+#pragma execution_character_set("utf-8")
+#pragma warning(disable:4566)
+#endif
+
+#include <libretro.h>
+
+/*
+ ********************************
+ * VERSION: 2.0
+ ********************************
+ *
+ * - 2.0: Add support for core options v2 interface
+ * - 1.3: Move translations to libretro_core_options_intl.h
+ *        - libretro_core_options_intl.h includes BOM and utf-8
+ *          fix for MSVC 2010-2013
+ *        - Added HAVE_NO_LANGEXTRA flag to disable translations
+ *          on platforms/compilers without BOM support
+ * - 1.2: Use core options v1 interface when
+ *        RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION is >= 1
+ *        (previously required RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION == 1)
+ * - 1.1: Support generation of core options v0 retro_core_option_value
+ *        arrays containing options with a single value
+ * - 1.0: First commit
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ ********************************
+ * Core Option Definitions
+ ********************************
+*/
+
+/* RETRO_LANGUAGE_JAPANESE */
+
+/* RETRO_LANGUAGE_FRENCH */
+
+/* RETRO_LANGUAGE_SPANISH */
+
+/* RETRO_LANGUAGE_GERMAN */
+
+/* RETRO_LANGUAGE_ITALIAN */
+
+/* RETRO_LANGUAGE_DUTCH */
+
+/* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+
+/* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+
+/* RETRO_LANGUAGE_RUSSIAN */
+
+/* RETRO_LANGUAGE_KOREAN */
+
+/* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+
+/* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+
+/* RETRO_LANGUAGE_ESPERANTO */
+
+/* RETRO_LANGUAGE_POLISH */
+
+/* RETRO_LANGUAGE_VIETNAMESE */
+
+/* RETRO_LANGUAGE_ARABIC */
+
+/* RETRO_LANGUAGE_GREEK */
+
+/* RETRO_LANGUAGE_TURKISH */
+
+/* RETRO_LANGUAGE_SLOVAK */
+
+/* RETRO_LANGUAGE_PERSIAN */
+
+/* RETRO_LANGUAGE_HEBREW */
+
+/* RETRO_LANGUAGE_ASTURIAN */
+
+/* RETRO_LANGUAGE_FINNISH */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libretro/include/retroscreen.h
+++ b/libretro/include/retroscreen.h
@@ -1,8 +1,7 @@
 #ifndef RETROSCREEN_H
 #define RETROSCREEN_H
 
-extern int VIRTUAL_WIDTH;
-extern int retrow ; 
-extern int retroh ;
+extern int retrow;
+extern int retroh;
 
 #endif

--- a/libretro/sdl_wrapp/sdl-wrapper.c
+++ b/libretro/sdl_wrapp/sdl-wrapper.c
@@ -186,6 +186,15 @@ void Retro_BlitSurface(SDL_Surface *ss,SDL_Rect* sr,SDL_Surface *ds,SDL_Rect* dr
                if(key!=*pin)*pout=*pin;
                pout++;pin++;
             }
+            else if(sBPP==1 && dBPP==2)
+            {
+               unsigned int mcoul=(ss->format->palette->colors[*pin].r>>3)<<11|\
+                                  (ss->format->palette->colors[*pin].g>>3)<<6|\
+                                  (ss->format->palette->colors[*pin].b>>3);
+               retro_unaligned16 (pout) = mcoul;
+               pout += 2;
+               pin++;
+            }
             else if(sBPP==1 && dBPP==4)
             {
                unsigned int mcoul=ss->format->palette->colors[*pin].r<<16|\
@@ -233,6 +242,15 @@ void Retro_BlitSurface(SDL_Surface *ss,SDL_Rect* sr,SDL_Surface *ds,SDL_Rect* dr
                                   ss->format->palette->colors[*pin].b;
                retro_unaligned32 (pout) = mcoul;
                pout += 4;
+               pin++;
+            }
+            else if(sBPP==1 && dBPP==2)
+            {
+               unsigned int mcoul=(ss->format->palette->colors[*pin].r>>3)<<11|\
+                                  (ss->format->palette->colors[*pin].g>>3)<<6|\
+                                  (ss->format->palette->colors[*pin].b>>3);
+               retro_unaligned16 (pout) = mcoul;
+               pout += 2;
                pin++;
             }
             else

--- a/src/data.c
+++ b/src/data.c
@@ -224,6 +224,7 @@ void data_file_close(data_file_t *file)
 		((zipped_t *)file)->zip = NULL;
 		free(((zipped_t *)file)->name);
 		((zipped_t *)file)->name = NULL;
+		free(file);
 	}
 	else
 		rfclose((RFILE *)file);

--- a/src/game.c
+++ b/src/game.c
@@ -33,28 +33,11 @@
 #include "devtools.h"
 #endif
 
-
-/*
- * local typedefs
- */
-typedef enum {
-#ifdef ENABLE_DEVTOOLS
-  DEVTOOLS,
-#endif
-  XRICK,
-  INIT_GAME, INIT_BUFFER,
-  INTRO_MAIN, INTRO_MAP,
-  PAUSE_PRESSED1, PAUSE_PRESSED1B, PAUSED, PAUSE_PRESSED2,
-  PLAY0, PLAY1, PLAY2, PLAY3,
-  CHAIN_SUBMAP, CHAIN_MAP, CHAIN_END,
-  SCROLL_UP, SCROLL_DOWN,
-  RESTART, GAMEOVER, GETNAME, EXIT
-} game_state_t;
-
-
 /*
  * global vars
  */
+game_state_t game_state;
+
 U8 game_period = 0;
 U8 game_waitevt = FALSE;
 rect_t *game_rects = NULL;
@@ -121,9 +104,8 @@ sound_t *WAV_ENTITY[10];
  * local vars
  */
 static U8 isave_frow;
-static game_state_t game_state;
 #ifdef ENABLE_SOUND
-static sound_t *music_snd;
+static sound_t *music_snd = NULL;
 #endif
 
 
@@ -581,6 +563,35 @@ game_toggleCheat(U8 nbr)
     sysvid_update(&draw_SCREENRECT);
   }
 }
+
+void game_enableCheats(U8 enable1, U8 enable2, U8 enable3)
+{
+  if (game_state != INTRO_MAIN && game_state != INTRO_MAP &&
+      game_state != GAMEOVER && game_state != GETNAME &&
+#ifdef ENABLE_DEVTOOLS
+      game_state != DEVTOOLS &&
+#endif
+      game_state != XRICK && game_state != EXIT)
+   {
+      if (enable1)
+      {
+         game_cheat1 = 1;
+         game_lives = 6;
+         game_bombs = 6;
+         game_bullets = 6;
+      }
+      else
+         game_cheat1 = 0;
+
+      game_cheat2 = enable2;
+      game_cheat3 = enable3;
+
+      draw_infos();
+      /* FIXME this should probably only raise a flag ... */
+      /* plus we only need to update INFORECT not the whole screen */
+      sysvid_update(&draw_SCREENRECT);
+   }
+}
 #endif
 
 #ifdef ENABLE_SOUND
@@ -590,7 +601,7 @@ game_toggleCheat(U8 nbr)
 void
 game_setmusic(char *name, U8 loop)
 {
-	U8 channel;
+	S8 channel;
 
 	if (music_snd)
 		game_stopmusic();

--- a/src/sysvid.c
+++ b/src/sysvid.c
@@ -25,10 +25,10 @@
 #include <memory.h> /* memset */
 #endif
 
-U8 *sysvid_fb; /* frame buffer */
+U8 *sysvid_fb = NULL; /* frame buffer */
 
 static SDL_Color palette[256];
-static SDL_Surface *screen;
+static SDL_Surface *screen = NULL;
 
 #include "img_icon.e"
 
@@ -122,6 +122,10 @@ void sysvid_shutdown(void)
    if (sysvid_fb)
       free(sysvid_fb);
    sysvid_fb = NULL;
+
+   if (screen)
+      SDL_FreeSurface(screen);
+   screen = NULL;
 }
 
 extern SDL_Surface *sdlscrn; 


### PR DESCRIPTION
I initially intended to only tweak the 'contentless' operation mode of this core in line with planned RetroArch frontend additions - but the core proved to be significantly broken, and I couldn't leave it in that state... Consequently, this PR makes the following changes:

- Set correct core provided aspect ratio
- Add core option for cropping the (typically empty) borders either side of the game screen (should always be enabled unless the user wishes to see cheat mode indicators)
- Fix rendering when using the RGB565 pixel format and use RGB565 on all platforms (for improved performance)
- Fix infinite ammo/dynamite bug
- Add core options to expose internal game engine cheat modes:
    - Trainer Mode: Always have 6 bullets, 6 dynamite stick, 6 lives
    - Invulnerability Mode: Nothing can kill Rick (Use with care, may break the game)
    - Expose Mode: Highlight all entities on the game map
- Add input descriptors and configure input mapping for a more modern control method:
    - D-Pad Left: Left
    - D-Pad Up: Up
    - D-Pad Right: Right
    - D-Pad Down: Down
    - RetroPad A: Jump
    - RetroPad B: Fire Gun
    - RetroPad X: Jab Stick (+ Left/Right)
    - RetroPad Y: Set Dynamite
    - RetroPad Start: Pause
- Improve 'contentless' operation
    - Game data is now loaded from `<system_dir>/xrick/data.zip` (previously the path was `<system_dir>/data.zip`, which could potentially conflict with other cores)
    - A suitable OSD error notification is displayed when attempting contentless operation without a valid file in the frontend system directory
- Fix (very) poor quality audio playback
- In-game high score table is now recorded via the frontend SRAM interface
- Fix memory leaks

System files for contentless operation will be available via RetroArch's online updater once this is merged: https://github.com/libretro/libretro-system-files/pull/7

Closes #16
Closes #15