### PR TITLE
Add OpenDingux build target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
 
+  # OpenDingux
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-mips32.yml'
+
   # tvOS (AppleTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
@@ -240,6 +244,18 @@ libretro-build-libnx-aarch64:
 libretro-build-vita:
   extends:
     - .libretro-vita-static-retroarch-master
+    - .core-defs
+
+# OpenDingux
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs
+
+# OpenDingux Beta
+libretro-build-dingux-odbeta-mips32:
+  extends:
+    - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs
 
 #################################### MISC ##################################

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -136,6 +136,16 @@ else ifeq ($(platform), ctr)
 	STATIC_LINKING = 1
 	STATIC_LINKING_LINK = 1
 
+# GCW0 (OpenDingux and OpenDingux Beta)
+else ifeq ($(platform), gcw0)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc
+	CXX = /opt/gcw0-toolchain/usr/bin/mipsel-linux-g++
+	AR = /opt/gcw0-toolchain/usr/bin/mipsel-linux-ar
+	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=$(CORE_DIR)/libretro/core/link.T
+	fpic := -fPIC
+	CFLAGS += -DDINGUX -fomit-frame-pointer -march=mips32 -mtune=mips32r2 -mhard-float
+
 # Nintendo Game Cube
 else ifeq ($(platform), ngc)
    TARGET := $(TARGET_NAME)_libretro_ngc.a


### PR DESCRIPTION
This PR adds a build target for OpenDingux platforms. The core runs full speed on an RG350M (with video integer scaling enabled).