### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -223,7 +223,7 @@ else ifeq ($(platform), wiiu)
 	BAKE_IN_ZLIB=1
    CFLAGS += \
 	-DHAVE_ASPRINTF -I$(DEVKITPRO)/libogc/include \
-	-DGEKKO -DWIIU -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float
+	-DGEKKO -DWIIU -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
 
    SHARED :=   -lm -lc
 	WANT_ZLIB=1


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)